### PR TITLE
Fix comment style issue

### DIFF
--- a/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
+++ b/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
@@ -1,5 +1,5 @@
-// Copyright (c) 2017 Intel Corporation. All rights reserved.
-// Use of this source code is governed by a MIT-style
-// license that can be found in the LICENSE file.
+# Copyright (c) 2017 Intel Corporation. All rights reserved.
+# Use of this source code is governed by a MIT-style
+# license that can be found in the LICENSE file.
 
 org.apache.hadoop.fs.LustreFileSystem


### PR DESCRIPTION
Should use "#" instead of "//" for comments in file org.apache.hadoop.fs.FileSystem