### PR TITLE
"lfs setstripe" uses "-S" to specify stripe size

### DIFF
--- a/src/main/java/org/apache/hadoop/lustre/io/LustreFsJavaImpl.java
+++ b/src/main/java/org/apache/hadoop/lustre/io/LustreFsJavaImpl.java
@@ -200,7 +200,7 @@ public class LustreFsJavaImpl implements LustreFsDelegate {
     if (stripeSize < 0L) {
       stripeSize = (1024 * 1024);
     }
-    args[argIndex++] = "-s";
+    args[argIndex++] = "-S";
     args[argIndex++] = String.valueOf(stripeSize);
 
     if (stripeCount < -1) {


### PR DESCRIPTION
Since lustre commit "46bec835", "lfs setstripe" uses option "-S" instead of "-s" to specify stripe size.