### PR TITLE
Update the installation reference in README.md Signed-off-by: Emoly Liu <emoly.liu@intel.com>

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,4 @@ Maven build goals:
 
 Installation:
 
-Please refer: https://wiki.hpdd.intel.com/display/SR/Installation+of+HAL+on+Apache+Hadoop
+Please refer "Installation of HAL on Apache Hadoop.md" in this directory for details.


### PR DESCRIPTION
Update the installation reference in README.md
    
Use "Installation of HAL on Apache Hadoop.md" for installation reference instead of the stale link https://wiki.hpdd.intel.com/display/SR/Installation+of+HAL+on+Apache+Hadoop .
    
Signed-off-by: Emoly Liu <emoly.liu@intel.com>